### PR TITLE
#64 fix(mesh controller): added back accidentally removed scaling

### DIFF
--- a/Virtual Modeller/Assets/Scripts/Controllers/MeshController.cs
+++ b/Virtual Modeller/Assets/Scripts/Controllers/MeshController.cs
@@ -101,6 +101,19 @@ public class MeshController : Singleton<MeshController> {
 		if (modelWasUpdated && _model.TrySmoothing()) {
 			modelWasUpdated = false;
 		}
+		
+		// scale down
+		Vector3 modelScale = _model.gameObject.transform.localScale;
+		Vector3 scalingVector = new Vector3(1f, 1f, 1f) * 0.001f;
+        if (Input.GetKey(",")) {
+			modelScale -= scalingVector;
+        }
+        // scale up
+        if (Input.GetKey("."))
+        {
+            modelScale += scalingVector;
+        }
+		_model.gameObject.transform.localScale = modelScale;
 	}
 
 	/*


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#64
## Purpose
<!--- A clear and concise description of what the PR does. -->
Adds scaling back
## Current behaviour
<!--- Tell us what currently happens -->
Scaling with , and . was accidentally removed
## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Scaling is back
## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
When , or . is detected by meshcontroller, scale model 